### PR TITLE
Add unicity.network platform site and unicity.ai AOS link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,7 +21,8 @@ Get started with [**Unicity AgentSphere**](https://sphere.unicity.network/) - a 
 * 👾 **[Chat with @kbbot](https://sphere.unicity.network/agents/chat?nametag=kbbot)** (Helpful Assistant with Unicity knowledge)
 
 #### Tools & Ecosystem
-* 🌅 **[Official Website](https://www.unicity.ai/)**
+* 🌐 **[Unicity Platform](https://unicity.network/)** — protocol, use cases, wallet, developer docs
+* 🤖 **[Unicity AOS](https://www.unicity.ai/)** — The Operating System for Autonomous AI
 * ✨ **[Unicity AgentSphere](https://sphere.unicity.network/)**
 * 👛 **[Web Wallet](https://unicitynetwork.github.io/webwallet/)**
 * 🛠️ **[Start Building (Sphere SDK)](https://github.com/unicity-sphere/sphere-sdk)**


### PR DESCRIPTION
Adds the unicity.network platform site to the org profile's Tools & Ecosystem section, and re-labels unicity.ai as the Unicity AOS product site (rather than "Official Website" generally).